### PR TITLE
Fixed bug where atoms passed through channels when they shouldn't

### DIFF
--- a/How Water Thinks/Assets/Resources/Prefabs/sodiumAtom.prefab
+++ b/How Water Thinks/Assets/Resources/Prefabs/sodiumAtom.prefab
@@ -40,7 +40,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1440897163994094}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 660.594, y: 215.81502, z: -204.6471}
+  m_LocalPosition: {x: 660.5013, y: 215.37271, z: -205.43692}
   m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
   m_Children: []
   m_Father: {fileID: 0}

--- a/How Water Thinks/Assets/Resources/Sprites_UI/8.jpg.meta
+++ b/How Water Thinks/Assets/Resources/Sprites_UI/8.jpg.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a299f90569e474108985a558d16a78ed
+guid: 59df24f4dc3ba42c6a710bfa516c2c15
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}

--- a/How Water Thinks/Assets/Resources/Sprites_UI/Medieval_Building_06.png.meta
+++ b/How Water Thinks/Assets/Resources/Sprites_UI/Medieval_Building_06.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 99655fa9321d5495f8df40f9415c14c7
+guid: a1b8442c9d04f41289d8040e59115a6f
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}

--- a/How Water Thinks/Assets/Resources/Sprites_UI/Ocean Sunrise1.4.png.meta
+++ b/How Water Thinks/Assets/Resources/Sprites_UI/Ocean Sunrise1.4.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 712fb0ddfbab84964a3723c05e597b4c
+guid: 2a3e523810a95483bb5ff95333d7a91e
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}

--- a/How Water Thinks/Assets/Resources/Sprites_UI/Tree.png.meta
+++ b/How Water Thinks/Assets/Resources/Sprites_UI/Tree.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c2e6120800584484d81464135614adad
+guid: 139d9c164cdad48cea6ea6a9dafa8972
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}

--- a/How Water Thinks/Assets/Resources/Sprites_UI/emerald_city.jpg.meta
+++ b/How Water Thinks/Assets/Resources/Sprites_UI/emerald_city.jpg.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 5e840c2c02ca74541958edd4753ff481
+guid: a4ffcd8f4e5e84b36b41f1a530b1c50e
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}

--- a/How Water Thinks/Assets/Resources/Sprites_UI/grass_template2.jpg.meta
+++ b/How Water Thinks/Assets/Resources/Sprites_UI/grass_template2.jpg.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 57245b5a3be264074b86f921fe9fd6af
+guid: 3df465531ff164afe929d485c8d31650
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}

--- a/How Water Thinks/Assets/Resources/Sprites_UI/grassy_background.jpg.meta
+++ b/How Water Thinks/Assets/Resources/Sprites_UI/grassy_background.jpg.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d5a53db2cb8a9425d92d1d75f9a2a86e
+guid: 42e1f4a0210f2453cb924f3f59061f3e
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}

--- a/How Water Thinks/Assets/Resources/Sprites_UI/horse-chestnut-tree.png.meta
+++ b/How Water Thinks/Assets/Resources/Sprites_UI/horse-chestnut-tree.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e244f80384692494bb69c33ab145a562
+guid: 34c9cb9d7562a4008a801f6895963c8b
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}

--- a/How Water Thinks/Assets/Resources/Sprites_UI/hut.png.meta
+++ b/How Water Thinks/Assets/Resources/Sprites_UI/hut.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c59a46930b22b4a51832f62e22ac15e7
+guid: 8cc9504ea1ebc4eb9b252bc0088c1f41
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}

--- a/How Water Thinks/Assets/Resources/Sprites_UI/kisspng-oriental-poppy-portable-network-graphics-watercolo-eitli-png-gelincik-resimleri-png-gelincik-nis-5cbdaf6622d6e2.2672560315559350781427.jpg.meta
+++ b/How Water Thinks/Assets/Resources/Sprites_UI/kisspng-oriental-poppy-portable-network-graphics-watercolo-eitli-png-gelincik-resimleri-png-gelincik-nis-5cbdaf6622d6e2.2672560315559350781427.jpg.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 97f366730bce24f3fa2be25a734db1d7
+guid: fae34c8f7a096484bb4b8b7ca8ae1b79
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}

--- a/How Water Thinks/Assets/Resources/Sprites_UI/kisspng-plant-stem-maize-field-corn-corn-design-5ad873c204e329.46251671152413485002.png.meta
+++ b/How Water Thinks/Assets/Resources/Sprites_UI/kisspng-plant-stem-maize-field-corn-corn-design-5ad873c204e329.46251671152413485002.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 530c41e02e55d465bbb3a29249dee09b
+guid: e6a0c2e6a7a6b40b587318d09f631623
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}

--- a/How Water Thinks/Assets/Resources/Sprites_UI/lake_background.png.meta
+++ b/How Water Thinks/Assets/Resources/Sprites_UI/lake_background.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8a49056ec3d484f1ebf84961b462230a
+guid: 6288e25a8316444e0a9acca16ab72c37
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}
@@ -86,7 +86,7 @@ TextureImporter:
     outline: []
     physicsShape: []
     bones: []
-    spriteID: 
+    spriteID: d9fd1c368f6494d51b7bdfb8fa530a60
     vertices: []
     indices: 
     edges: []

--- a/How Water Thinks/Assets/Resources/Sprites_UI/output-onlinepngtools (1).png.meta
+++ b/How Water Thinks/Assets/Resources/Sprites_UI/output-onlinepngtools (1).png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f644898afbb4d43b4bd06fc2b9f54a5e
+guid: 3e919938aa5704bf09e74dec3c474364
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}

--- a/How Water Thinks/Assets/Resources/Sprites_UI/tree_1.jpg.meta
+++ b/How Water Thinks/Assets/Resources/Sprites_UI/tree_1.jpg.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d50061772008541c3812d9bf975062f0
+guid: a75607af7913946aa8e5dc015514c451
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}

--- a/How Water Thinks/Assets/Resources/Sprites_UI/tree_2.png.meta
+++ b/How Water Thinks/Assets/Resources/Sprites_UI/tree_2.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 26cfecbc10de74cc697c997f2a8b1473
+guid: 59084efe4e787437e83f7ddf05a3e03b
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}

--- a/How Water Thinks/Assets/Resources/Sprites_UI/tree_3.jpeg.meta
+++ b/How Water Thinks/Assets/Resources/Sprites_UI/tree_3.jpeg.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9807fff3d10c349c49c452b0122e8a2b
+guid: d33685d20af494541b83cf790fd0e7a6
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}

--- a/How Water Thinks/Assets/Resources/Sprites_UI/tree_4.jpg.meta
+++ b/How Water Thinks/Assets/Resources/Sprites_UI/tree_4.jpg.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 3989e606b0bc64100b609400f84904d1
+guid: 97db1ddc70a59458b9fd4e1023a4a1f6
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}

--- a/How Water Thinks/Assets/Resources/Sprites_UI/water_puddle.jpeg.meta
+++ b/How Water Thinks/Assets/Resources/Sprites_UI/water_puddle.jpeg.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 420a8dfecc46f40749f9e3abda52eaa8
+guid: aa5cfcbaf07624a77a0ca78c9ad01bfd
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}

--- a/How Water Thinks/Assets/Resources/Sprites_UI/yellow_brick_road.jpg.meta
+++ b/How Water Thinks/Assets/Resources/Sprites_UI/yellow_brick_road.jpg.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 98aa7dadeeecb40b6b5003b0b3e1ebf8
+guid: a6c1cb1000d35469e83d5306af393ef2
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}

--- a/How Water Thinks/Assets/Scenes/Level 1.unity
+++ b/How Water Thinks/Assets/Scenes/Level 1.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.37311953, g: 0.38074014, b: 0.3587274, a: 1}
+  m_IndirectSpecularColor: {r: 0.3731193, g: 0.38073996, b: 0.3587269, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -5454,7 +5454,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -0.00012207031, y: -390.03003}
+  m_AnchoredPosition: {x: 0, y: -390.03003}
   m_SizeDelta: {x: 0, y: -779.95}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &608517438
@@ -10500,7 +10500,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -0.00012207031, y: -390.03003}
+  m_AnchoredPosition: {x: 0, y: -390.03003}
   m_SizeDelta: {x: 0, y: -779.95}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1012853591
@@ -11688,7 +11688,7 @@ BoxCollider:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1195256355}
   m_Material: {fileID: 0}
-  m_IsTrigger: 1
+  m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
   m_Size: {x: 1.0000001, y: 1, z: 1.0000002}
@@ -16540,7 +16540,7 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1809970296}
   m_LocalRotation: {x: -0, y: -1, z: -0, w: 0}
-  m_LocalPosition: {x: 1.0999756, y: 0.101, z: 0}
+  m_LocalPosition: {x: 1.0999756, y: 0.09, z: 0}
   m_LocalScale: {x: 1, y: 0.1, z: 1}
   m_Children: []
   m_Father: {fileID: 1383374848}
@@ -16564,7 +16564,7 @@ BoxCollider:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1809970296}
   m_Material: {fileID: 0}
-  m_IsTrigger: 1
+  m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
   m_Size: {x: 1.0000001, y: 1, z: 1.0000002}

--- a/How Water Thinks/Assets/Scripts/CountdownTimer.cs
+++ b/How Water Thinks/Assets/Scripts/CountdownTimer.cs
@@ -33,19 +33,19 @@ public class CountdownTimer : MonoBehaviour {
 		sceneName = currentScene.name;
 		if (sceneName == "Level 0")
 		{
-			if (t > 45)
+			if (t > 35)
 			{
 				star1.SetActive(false);
 				star2.SetActive(false);
 				star3.SetActive(false);
 			}
-			else if (t > 30)
+			else if (t > 25)
 			{
 				star1.SetActive(false);
 				star2.SetActive(false);
 				star3.SetActive(true);
 			}
-			else if (t > 15)
+			else if (t > 20)
 			{
 				star1.SetActive(false);
 				star2.SetActive(true);
@@ -60,19 +60,19 @@ public class CountdownTimer : MonoBehaviour {
 		}
 		else if (sceneName == "Level 1")
 		{
-			if (t > 45)
+			if (t > 70)
 			{
 				star1.SetActive(false);
 				star2.SetActive(false);
 				star3.SetActive(false);
 			}
-			else if (t > 30)
+			else if (t > 55)
 			{
 				star1.SetActive(false);
 				star2.SetActive(false);
 				star3.SetActive(true);
 			}
-			else if (t > 15)
+			else if (t > 45)
 			{
 				star1.SetActive(false);
 				star2.SetActive(true);
@@ -85,5 +85,35 @@ public class CountdownTimer : MonoBehaviour {
 				star3.SetActive(true);
 			}
 		}
+<<<<<<< Updated upstream
+=======
+		else if (sceneName == "Level 3")
+		{
+			if (t > 50)
+			{
+				star1.SetActive(false);
+				star2.SetActive(false);
+				star3.SetActive(false);
+			}
+			else if (t > 40)
+			{
+				star1.SetActive(false);
+				star2.SetActive(false);
+				star3.SetActive(true);
+			}
+			else if (t > 35)
+			{
+				star1.SetActive(false);
+				star2.SetActive(true);
+				star3.SetActive(true);
+			}
+			else
+			{
+				star1.SetActive(true);
+				star2.SetActive(true);
+				star3.SetActive(true);
+			}
+		}
+>>>>>>> Stashed changes
 	}
 }

--- a/How Water Thinks/Assets/Scripts/EnforceVelocity.cs
+++ b/How Water Thinks/Assets/Scripts/EnforceVelocity.cs
@@ -29,8 +29,10 @@ public class EnforceVelocity : MonoBehaviour {
 		string sceneName = currentScene.name;
 		if (sceneName == "Level 0") {
 			temp = 1;
+		} else if (sceneName == "Level 1") {
+			temp = 4;
 		} else {
-			temp = 1;
+			temp = 4;
 		}
 		float idealVelocity = temp * 1f;
 		this.gameObject.GetComponent<Rigidbody>().velocity = idealVelocity * this.gameObject.GetComponent<Rigidbody>().velocity.normalized;

--- a/How Water Thinks/Assets/Scripts/HandleForceTrigger.cs
+++ b/How Water Thinks/Assets/Scripts/HandleForceTrigger.cs
@@ -13,8 +13,9 @@ public class HandleForceTrigger : MonoBehaviour
 
     }
 
-    private void OnTriggerEnter(Collider c)
-    {
+ void OnCollisionEnter(Collision c)
+  {
+
         Scene currentScene = SceneManager.GetActiveScene();
         string sceneName = currentScene.name;
         if (sceneName == "Level 3") {
@@ -30,23 +31,18 @@ public class HandleForceTrigger : MonoBehaviour
                         if (c.gameObject.transform.position.y > 214.95)
                         {
                             //GameObject.Find("AtomCrossingSound").GetComponent<AudioSource>().Play();
-                            return;
+                            Physics.IgnoreCollision(c.collider, GetComponent<Collider>());
+
                         }
                         else
                         {
-                            c.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, -100, 0));
+                            
+                            return;
                         }
                     }
                     else
                     {
-                        if (c.gameObject.transform.position.y > 214.95)
-                        {
-                            c.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, 100, 0));
-                        }
-                        else
-                        {
-                            c.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, -100, 0));
-                        }
+                        return;
                     }
                 }
                 else if (this.tag == "KForce")
@@ -56,23 +52,17 @@ public class HandleForceTrigger : MonoBehaviour
                         if (c.gameObject.transform.position.y > 214.95)
                         {
                             //GameObject.Find("AtomCrossingSound").GetComponent<AudioSource>().Play();
+                            Physics.IgnoreCollision(c.collider, GetComponent<Collider>());
+
+                        }
+                        else
+                        {
                             return;
                         }
-                        else
-                        {
-                            c.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, -100, 0));
-                        }
                     }
-                    else
+                    else 
                     {
-                        if (c.gameObject.transform.position.y > 214.95)
-                        {
-                            c.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, 100, 0));
-                        }
-                        else
-                        {
-                            c.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, -100, 0));
-                        }
+                        return;
                     }
                 }
             } else if (totalVoltage <= -70) {
@@ -83,23 +73,17 @@ public class HandleForceTrigger : MonoBehaviour
                         if (c.gameObject.transform.position.y < 214.95)
                         {
                             //GameObject.Find("AtomCrossingSound").GetComponent<AudioSource>().Play();
-                            return;
+                            Physics.IgnoreCollision(c.collider, GetComponent<Collider>());
+
                         }
                         else
                         {
-                            c.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, 100, 0));
+                            return;
                         }
                     }
                     else
                     {
-                        if (c.gameObject.transform.position.y > 214.95)
-                        {
-                            c.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, 100, 0));
-                        }
-                        else
-                        {
-                            c.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, -100, 0));
-                        }
+                        return;
                     }
                 }
                 else if (this.tag == "KForce")
@@ -109,23 +93,17 @@ public class HandleForceTrigger : MonoBehaviour
                         if (c.gameObject.transform.position.y < 214.95)
                         {
                             //GameObject.Find("AtomCrossingSound").GetComponent<AudioSource>().Play();
-                            return;
+                            Physics.IgnoreCollision(c.collider, GetComponent<Collider>());
+
                         }
                         else
                         {
-                            c.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, 100, 0));
+                            return;
                         }
                     }
                     else
                     {
-                        if (c.gameObject.transform.position.y > 214.95)
-                        {
-                            c.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, 100, 0));
-                        }
-                        else
-                        {
-                            c.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, -100, 0));
-                        }
+                        Physics.IgnoreCollision(c.collider, GetComponent<Collider>());
                     }
                 }
             }
@@ -135,18 +113,11 @@ public class HandleForceTrigger : MonoBehaviour
                     if (c.gameObject.tag == "SodiumAtom")
                     {
                         //GameObject.Find("AtomCrossingSound").GetComponent<AudioSource>().Play();
-                        return;
+                        Physics.IgnoreCollision(c.collider, GetComponent<Collider>());
                     }
                     else
                     {
-                        if (c.gameObject.transform.position.y > 214.95)
-                        {
-                            c.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, 100, 0));
-                        }
-                        else
-                        {
-                            c.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, -100, 0));
-                        }
+                        Physics.IgnoreCollision(c.collider, GetComponent<Collider>());
                     }
                 }
                 else if (this.tag == "KForce")
@@ -155,64 +126,244 @@ public class HandleForceTrigger : MonoBehaviour
                     if (c.gameObject.tag == "PotassiumAtom")
                     {
                         //GameObject.Find("AtomCrossingSound").GetComponent<AudioSource>().Play();
-                        return;
+                        Physics.IgnoreCollision(c.collider, GetComponent<Collider>());
                     }
                     else
                     {
-                        if (c.gameObject.transform.position.y > 214.95)
-                        {
-                            c.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, 100, 0));
-                        }
-                        else
-                        {
-                            c.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, -100, 0));
-                        }
+                        return;
                     }
                 }
             }
         }
-        else {
+        else { // level 1 or 2
             if (this.tag == "NaForce")
             {
                 if (c.gameObject.tag == "SodiumAtom")
                 {
-                    // GameObject.Find("AtomCrossingSound").GetComponent<AudioSource>().Play();
-                    return;
-                }
-                else
-                {
-                    if (c.gameObject.transform.position.y > 214.95)
-                    {
-                        c.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, 100, 0));
-                    }
-                    else
-                    {
-                        c.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, -100, 0));
-                    }
+                    Physics.IgnoreCollision(c.collider, GetComponent<Collider>());
                 }
             }
             else if (this.tag == "KForce")
             {
-                
                 if (c.gameObject.tag == "PotassiumAtom")
                 {
-                    //GameObject.Find("AtomCrossingSound").GetComponent<AudioSource>().Play();
-                    return;
-                }
-                else
-                {
-                    if (c.gameObject.transform.position.y > 214.95)
-                    {
-                        c.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, 100, 0));
-                    }
-                    else
-                    {
-                        c.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, -100, 0));
-                    }
+                    Physics.IgnoreCollision(c.collider, GetComponent<Collider>());
                 }
             }
-        }
-    }
+  }
+  }
+
+
+    // private void OnTriggerEnter(Collider c)
+    // {
+    //     Scene currentScene = SceneManager.GetActiveScene();
+    //     string sceneName = currentScene.name;
+    //     if (sceneName == "Level 3") {
+    //         //float voltageOuter = GameObject.FindGameObjectWithTag("RunControl").GetComponent<AtomCount>().getVoltageOuter();
+    //         //float voltageInner = GameObject.FindGameObjectWithTag("RunControl").GetComponent<AtomCount>().getVoltageInner();
+    //         float totalVoltage = GameObject.FindGameObjectWithTag("RunControl").GetComponent<AtomCount>().getVoltage();
+    //         //print(totalVoltage);
+    //         if (totalVoltage >= 70) {
+    //             if (this.tag == "NaForce")
+    //             {
+    //                 if (c.gameObject.tag == "SodiumAtom")
+    //                 {
+    //                     if (c.gameObject.transform.position.y > 214.95)
+    //                     {
+    //                         //GameObject.Find("AtomCrossingSound").GetComponent<AudioSource>().Play();
+    //                         return;
+    //                     }
+    //                     else
+    //                     {
+                            
+    //                         c.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, -100, 0));
+    //                     }
+    //                 }
+    //                 else
+    //                 {
+    //                     if (c.gameObject.transform.position.y > 214.95)
+    //                     {
+    //                         c.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, 100, 0));
+    //                     }
+    //                     else
+    //                     {
+    //                         c.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, -100, 0));
+    //                     }
+    //                 }
+    //             }
+    //             else if (this.tag == "KForce")
+    //             {
+    //                 if (c.gameObject.tag == "PotassiumAtom")
+    //                 {
+    //                     if (c.gameObject.transform.position.y > 214.95)
+    //                     {
+    //                         //GameObject.Find("AtomCrossingSound").GetComponent<AudioSource>().Play();
+    //                         return;
+    //                     }
+    //                     else
+    //                     {
+    //                         c.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, -100, 0));
+    //                     }
+    //                 }
+    //                 else 
+    //                 {
+    //                     if (c.gameObject.transform.position.y > 214.95)
+    //                     {
+    //                         c.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, 100, 0));
+    //                     }
+    //                     else
+    //                     {
+    //                         c.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, -100, 0));
+    //                     }
+    //                 }
+    //             }
+    //         } else if (totalVoltage <= -70) {
+    //             if (this.tag == "NaForce")
+    //             {
+    //                 if (c.gameObject.tag == "SodiumAtom")
+    //                 {
+    //                     if (c.gameObject.transform.position.y < 214.95)
+    //                     {
+    //                         //GameObject.Find("AtomCrossingSound").GetComponent<AudioSource>().Play();
+    //                         return;
+    //                     }
+    //                     else
+    //                     {
+    //                         c.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, 100, 0));
+    //                     }
+    //                 }
+    //                 else
+    //                 {
+    //                     if (c.gameObject.transform.position.y > 214.95)
+    //                     {
+    //                         c.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, 100, 0));
+    //                     }
+    //                     else
+    //                     {
+    //                         c.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, -100, 0));
+    //                     }
+    //                 }
+    //             }
+    //             else if (this.tag == "KForce")
+    //             {
+    //                 if (c.gameObject.tag == "PotassiumAtom")
+    //                 {
+    //                     if (c.gameObject.transform.position.y < 214.95)
+    //                     {
+    //                         //GameObject.Find("AtomCrossingSound").GetComponent<AudioSource>().Play();
+    //                         return;
+    //                     }
+    //                     else
+    //                     {
+    //                         c.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, 100, 0));
+    //                     }
+    //                 }
+    //                 else
+    //                 {
+    //                     if (c.gameObject.transform.position.y > 214.95)
+    //                     {
+    //                         c.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, 100, 0));
+    //                     }
+    //                     else
+    //                     {
+    //                         c.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, -100, 0));
+    //                     }
+    //                 }
+    //             }
+    //         }
+    //         else {
+    //             if (this.tag == "NaForce")
+    //             {
+    //                 if (c.gameObject.tag == "SodiumAtom")
+    //                 {
+    //                     //GameObject.Find("AtomCrossingSound").GetComponent<AudioSource>().Play();
+    //                     return;
+    //                 }
+    //                 else
+    //                 {
+    //                     if (c.gameObject.transform.position.y > 214.95)
+    //                     {
+    //                         c.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, 100, 0));
+    //                     }
+    //                     else
+    //                     {
+    //                         c.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, -100, 0));
+    //                     }
+    //                 }
+    //             }
+    //             else if (this.tag == "KForce")
+    //             {
+                    
+    //                 if (c.gameObject.tag == "PotassiumAtom")
+    //                 {
+    //                     //GameObject.Find("AtomCrossingSound").GetComponent<AudioSource>().Play();
+    //                     return;
+    //                 }
+    //                 else
+    //                 {
+    //                     if (c.gameObject.transform.position.y > 214.95)
+    //                     {
+    //                         c.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, 100, 0));
+    //                     }
+    //                     else
+    //                     {
+    //                         c.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, -100, 0));
+    //                     }
+    //                 }
+    //             }
+    //         }
+    //     }
+    //     else { // level < 3
+            // if (this.tag == "NaForce")
+            // {
+            //     if (c.gameObject.tag == "SodiumAtom")
+            //     {
+            //         // GameObject.Find("AtomCrossingSound").GetComponent<AudioSource>().Play();
+            //         return;
+            //     }
+            //     else
+            //     {
+            //         if (c.gameObject.transform.position.y > 214.95)
+            //         {
+            //             c.gameObject.GetComponent<Rigidbody>().velocity = new Vector3(c.gameObject.GetComponent<Rigidbody>().velocity.x, c.gameObject.GetComponent<Rigidbody>().velocity.y * -1, c.gameObject.GetComponent<Rigidbody>().velocity.z);
+            //             c.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, 100, 0));
+            //         }
+            //         else
+            //         {
+            //             c.gameObject.GetComponent<Rigidbody>().velocity = new Vector3(c.gameObject.GetComponent<Rigidbody>().velocity.x, c.gameObject.GetComponent<Rigidbody>().velocity.y * -1, c.gameObject.GetComponent<Rigidbody>().velocity.z);
+            //             c.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, -100, 0));
+            //         }
+            //     }
+            // }
+            // else if (this.tag == "KForce")
+            // {
+                
+            //     if (c.gameObject.tag == "PotassiumAtom")
+            //     {
+            //         //GameObject.Find("AtomCrossingSound").GetComponent<AudioSource>().Play();
+            //         return;
+            //     }
+            //     else
+            //     {
+            //         if (c.gameObject.transform.position.y > 214.95)
+            //         {
+            //             // c.gameObject.GetComponent<Rigidbody>().velocity = new Vector3(0, 0, 0);
+            //             c.gameObject.GetComponent<Rigidbody>().velocity = new Vector3(c.gameObject.GetComponent<Rigidbody>().velocity.x, c.gameObject.GetComponent<Rigidbody>().velocity.y * -1, c.gameObject.GetComponent<Rigidbody>().velocity.z);
+            //             // c.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, 100, 0));
+
+            //         }
+            //         else
+            //         {
+            //             // c.gameObject.GetComponent<Rigidbody>().velocity = new Vector3(0, 0, 0);
+
+            //             c.gameObject.GetComponent<Rigidbody>().velocity = new Vector3(c.gameObject.GetComponent<Rigidbody>().velocity.x, c.gameObject.GetComponent<Rigidbody>().velocity.y * -1, c.gameObject.GetComponent<Rigidbody>().velocity.z);
+            //             // c.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, -100, 0));
+
+            //         }
+            //     }
+            // }
+    //     }
+    // }
 
     // private void OnTriggerEnter(Collider c)
     // {

--- a/How Water Thinks/Assets/Sprites_UI.meta
+++ b/How Water Thinks/Assets/Sprites_UI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8b7ecf7a4faf44cfda332168df9ed947
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/How Water Thinks/Assets/Sprites_UI/8.jpg.meta
+++ b/How Water Thinks/Assets/Sprites_UI/8.jpg.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a299f90569e474108985a558d16a78ed
+guid: f3d773810cdd4443591da4ecac046912
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}

--- a/How Water Thinks/Assets/Sprites_UI/Medieval_Building_06.png.meta
+++ b/How Water Thinks/Assets/Sprites_UI/Medieval_Building_06.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 99655fa9321d5495f8df40f9415c14c7
+guid: 572152ca5482a4270b4b75ea9437d4bb
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}
@@ -86,7 +86,7 @@ TextureImporter:
     outline: []
     physicsShape: []
     bones: []
-    spriteID: 
+    spriteID: ca3e7211029e246c1ae017e43b7f2d2e
     vertices: []
     indices: 
     edges: []

--- a/How Water Thinks/Assets/Sprites_UI/Ocean Sunrise1.4.png.meta
+++ b/How Water Thinks/Assets/Sprites_UI/Ocean Sunrise1.4.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 712fb0ddfbab84964a3723c05e597b4c
+guid: 41afa02ca111d48b09345447b0a433ae
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}

--- a/How Water Thinks/Assets/Sprites_UI/Tree.png.meta
+++ b/How Water Thinks/Assets/Sprites_UI/Tree.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c2e6120800584484d81464135614adad
+guid: 80bc50ab58e9b41c79c5997621b29a4e
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}

--- a/How Water Thinks/Assets/Sprites_UI/emerald_city.jpg.meta
+++ b/How Water Thinks/Assets/Sprites_UI/emerald_city.jpg.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 5e840c2c02ca74541958edd4753ff481
+guid: a6fbcca96289445c3806609c6b00ea08
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}

--- a/How Water Thinks/Assets/Sprites_UI/grass_template2.jpg.meta
+++ b/How Water Thinks/Assets/Sprites_UI/grass_template2.jpg.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 57245b5a3be264074b86f921fe9fd6af
+guid: e25893038c5f24441bc88e91d484955c
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}

--- a/How Water Thinks/Assets/Sprites_UI/grassy_background.jpg.meta
+++ b/How Water Thinks/Assets/Sprites_UI/grassy_background.jpg.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d5a53db2cb8a9425d92d1d75f9a2a86e
+guid: ee2915b0392ce48cdbf509bd1edef7ae
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}

--- a/How Water Thinks/Assets/Sprites_UI/horse-chestnut-tree.png.meta
+++ b/How Water Thinks/Assets/Sprites_UI/horse-chestnut-tree.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e244f80384692494bb69c33ab145a562
+guid: 87d6d8d12a130422ca5422c5ff90fc84
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}
@@ -86,7 +86,7 @@ TextureImporter:
     outline: []
     physicsShape: []
     bones: []
-    spriteID: 
+    spriteID: ba860ec0a38484afc8ecd47ee1bd20af
     vertices: []
     indices: 
     edges: []

--- a/How Water Thinks/Assets/Sprites_UI/hut.png.meta
+++ b/How Water Thinks/Assets/Sprites_UI/hut.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c59a46930b22b4a51832f62e22ac15e7
+guid: 620634ad2738e4c43873dcca66e93afb
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}
@@ -86,7 +86,7 @@ TextureImporter:
     outline: []
     physicsShape: []
     bones: []
-    spriteID: 
+    spriteID: d3c3c504944f54a429241474f1613527
     vertices: []
     indices: 
     edges: []

--- a/How Water Thinks/Assets/Sprites_UI/kisspng-oriental-poppy-portable-network-graphics-watercolo-eitli-png-gelincik-resimleri-png-gelincik-nis-5cbdaf6622d6e2.2672560315559350781427.jpg.meta
+++ b/How Water Thinks/Assets/Sprites_UI/kisspng-oriental-poppy-portable-network-graphics-watercolo-eitli-png-gelincik-resimleri-png-gelincik-nis-5cbdaf6622d6e2.2672560315559350781427.jpg.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 97f366730bce24f3fa2be25a734db1d7
+guid: 4e6c85802de8242a58cef70d16565d8a
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}

--- a/How Water Thinks/Assets/Sprites_UI/kisspng-plant-stem-maize-field-corn-corn-design-5ad873c204e329.46251671152413485002.png.meta
+++ b/How Water Thinks/Assets/Sprites_UI/kisspng-plant-stem-maize-field-corn-corn-design-5ad873c204e329.46251671152413485002.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 530c41e02e55d465bbb3a29249dee09b
+guid: 663d50a8b7e454e5da8f352470382e15
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}
@@ -86,7 +86,7 @@ TextureImporter:
     outline: []
     physicsShape: []
     bones: []
-    spriteID: 
+    spriteID: 0ae74ce5bb0b34fdc9b389036b1e486c
     vertices: []
     indices: 
     edges: []

--- a/How Water Thinks/Assets/Sprites_UI/lake_background.png.meta
+++ b/How Water Thinks/Assets/Sprites_UI/lake_background.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8a49056ec3d484f1ebf84961b462230a
+guid: 0edfe5a4302324e759fd343a5ff72553
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}
@@ -86,7 +86,7 @@ TextureImporter:
     outline: []
     physicsShape: []
     bones: []
-    spriteID: 
+    spriteID: 25af6693f85174d96888652ca87439ab
     vertices: []
     indices: 
     edges: []

--- a/How Water Thinks/Assets/Sprites_UI/poppy.png.meta
+++ b/How Water Thinks/Assets/Sprites_UI/poppy.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f644898afbb4d43b4bd06fc2b9f54a5e
+guid: 8892050f3250b4ebca43f0d480860d47
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}
@@ -86,7 +86,7 @@ TextureImporter:
     outline: []
     physicsShape: []
     bones: []
-    spriteID: 
+    spriteID: 9d77b071e3d1349a89cdbbeef65f1b5a
     vertices: []
     indices: 
     edges: []

--- a/How Water Thinks/Assets/Sprites_UI/tree_1.jpg.meta
+++ b/How Water Thinks/Assets/Sprites_UI/tree_1.jpg.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d50061772008541c3812d9bf975062f0
+guid: 5602ec10f30b347f782ae7e0373930a7
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}

--- a/How Water Thinks/Assets/Sprites_UI/tree_2.png.meta
+++ b/How Water Thinks/Assets/Sprites_UI/tree_2.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 26cfecbc10de74cc697c997f2a8b1473
+guid: 03fd51732df00478da15cdab01c5aa1d
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}

--- a/How Water Thinks/Assets/Sprites_UI/tree_3.jpeg.meta
+++ b/How Water Thinks/Assets/Sprites_UI/tree_3.jpeg.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9807fff3d10c349c49c452b0122e8a2b
+guid: a8a0d0324bb1a46d8abea6fcad8a2851
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}

--- a/How Water Thinks/Assets/Sprites_UI/tree_4.jpg.meta
+++ b/How Water Thinks/Assets/Sprites_UI/tree_4.jpg.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 3989e606b0bc64100b609400f84904d1
+guid: 58be37e045f5e4d1b9eba46c13cdcd2e
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}

--- a/How Water Thinks/Assets/Sprites_UI/water_puddle.jpeg.meta
+++ b/How Water Thinks/Assets/Sprites_UI/water_puddle.jpeg.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 420a8dfecc46f40749f9e3abda52eaa8
+guid: d0483d4a2bcd141258786b5279d17bda
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}

--- a/How Water Thinks/Assets/Sprites_UI/yellow_brick_road.jpg.meta
+++ b/How Water Thinks/Assets/Sprites_UI/yellow_brick_road.jpg.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 98aa7dadeeecb40b6b5003b0b3e1ebf8
+guid: c05a9883281424670bef56ec9254a2dc
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}
@@ -86,7 +86,7 @@ TextureImporter:
     outline: []
     physicsShape: []
     bones: []
-    spriteID: 
+    spriteID: 3583d1287893a4882aa61640bf8e438f
     vertices: []
     indices: 
     edges: []


### PR DESCRIPTION
Disabled isTrigger on Membrane Channels.
In HandleForceTrigger.cs, replaced OnTriggerEnter method with new OnCollisionEnter method.
Instead of forcing away the wrong molecules, I only allow the correct molecules to pass through.